### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/abilian/crm/models.py
+++ b/abilian/crm/models.py
@@ -44,5 +44,5 @@ class PhoneNumber(IdMixin, Model):
             self.number = u''
         if not self.type:
             self.type = u''
-        return u'%s: %s' % (self.type, format_phonenumber(self.number,
+        return u'{0!s}: {1!s}'.format(self.type, format_phonenumber(self.number,
                                                           international=True))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:abilian:abilian-crm-core?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:abilian:abilian-crm-core?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
